### PR TITLE
fix: 지도 페이지 background-image 주소 인식 문제 해결

### DIFF
--- a/Client/src/pages/Map.tsx
+++ b/Client/src/pages/Map.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import KakaoMap from "../components/KakaoMap";
 import { regionDummy } from "../data/regionData";
 import { useState, useEffect } from "react";
@@ -20,6 +20,7 @@ import MobileHeaderBack from "../components/Header/MobileHeaderBack";
 import { MenuSideBar, MenuButton } from "./MainResponsive";
 import { Link } from "react-router-dom";
 import { isModalVisible } from "../recoil/setOverlay";
+import encodeURLForBackgroundImage from "../utils/encodeImgURL";
 
 interface RegionType {
   attractionAddress: string;
@@ -63,6 +64,14 @@ const Map = () => {
   const [isVoted, setIsVoted] = useState<boolean>();
   const [isLiked, setIsLiked] = useState<boolean>();
   const navigate = useNavigate();
+
+  const regionURLList = useMemo(
+    () =>
+      regionList?.map((el: RegionType) =>
+        encodeURLForBackgroundImage(el.fixedImage)
+      ),
+    [regionList]
+  );
 
   const url = "/attractions/maps?page=1&size=104&sort=posts";
   const url2 = `/attractions/${modalDataId}`;
@@ -197,7 +206,7 @@ const Map = () => {
                         setModalDataId(el.attractionId);
                         setFilterOrPosition(false);
                       }}
-                      imgUrl={el.fixedImage}
+                      imgUrl={regionURLList[index]}
                       key={el.attractionId}
                     >
                       <div>{el.attractionName}</div>

--- a/Client/src/utils/encodeImgURL.ts
+++ b/Client/src/utils/encodeImgURL.ts
@@ -1,0 +1,14 @@
+const charMap: Record<string, string> = {
+  "!": "%21",
+  "'": "%27",
+  "(": "%28",
+  ")": "%29",
+  "*": "%2A",
+  " ": "%20",
+};
+
+/**background-image url()을 위한 주소 문자열 인코딩 */
+function encodeURLForBackgroundImage(url: string) {
+  return url.replace(/[ !'()*]/g, (c) => charMap[c]);
+}
+export default encodeURLForBackgroundImage;


### PR DESCRIPTION
## 작업 내용
- css 속성인 background-image의 url 함수에서 인식 오류가 나서 대다수의 명소 이미지 오류 발생
- 이미지 주소의 특수 문자들을 인코딩하여 오류 해결
![Screenshot PIKCHA1](https://github.com/user-attachments/assets/9a846a7c-33fa-4a5e-a979-f00e6f21aed6)
![Screenshot  PIKCHA2](https://github.com/user-attachments/assets/1d1c8ff3-f12e-4f6c-b85b-48ad82ab5d5c)
