### PR TITLE
fix: 포스트 댓글 수정 없이 완료 시 빈 값 전송 문제 해결

### DIFF
--- a/Client/src/components/DetailPost/AddComment/index.tsx
+++ b/Client/src/components/DetailPost/AddComment/index.tsx
@@ -6,6 +6,7 @@ import Button from "~/components/@common/Button";
 import { UserDataAtomFamily } from "~/recoil/auth";
 import { isLoginModalVisibleAtom } from "~/recoil/modal/atoms";
 import * as S from "./styled";
+import { profileImg } from "~/data/userData";
 
 const AddComment = () => {
   const [addComment, setAddComment] = useState("");
@@ -17,12 +18,7 @@ const AddComment = () => {
     <S.AddCommentWrapper isLogin={isLogin}>
       <h3>댓글 남기기</h3>
       <div>
-        <img
-          src={
-            "https://drive.google.com/uc?id=1OmsgU1GLU9iUBYe9ruw_Uy1AcrN57n4g"
-          }
-          alt="userImg"
-        />
+        <img src={profileImg} alt="userImg" />
         <textarea
           placeholder={
             isLogin ? "댓글을 남겨주세요!" : "로그인 후 사용해주세요."

--- a/Client/src/components/DetailPost/Comment/index.tsx
+++ b/Client/src/components/DetailPost/Comment/index.tsx
@@ -13,6 +13,11 @@ import * as DP from "../styled";
 import { CommentType } from "~/@types/detailPost.types";
 import { ReCommentType } from "../types";
 
+type TContentState = {
+  recommentContent: string;
+  editcommentContent: string | null;
+};
+
 const Comment = ({
   comments,
   postWriter,
@@ -23,15 +28,23 @@ const Comment = ({
   const [isEdit, setIsEdit] = useState(false);
   const [isRecomment, setIsRecomment] = useState(false);
   const [commentIdx, setCommentIdx] = useState(0);
-  const [content, setContent] = useState({
+  const [content, setContent] = useState<TContentState>({
     recommentContent: "",
-    editcommentContent: "",
+    editcommentContent: null,
   });
   const { recommentContent, editcommentContent } = content;
   const [isMoreRecomment, setIsMoreReomment] = useState(false);
   const [memberId] = useRecoilState(UserDataAtomFamily.MEMBER_ID);
   const setIsLoginModalVisible = useSetRecoilState(isLoginModalVisibleAtom);
   const { postId } = useParams();
+
+  const handleEditComplete = () => {
+    if (editcommentContent === null) {
+      setIsEdit(false);
+      return;
+    }
+    modifiedComment(comments.commentId, editcommentContent);
+  };
 
   return (
     <>
@@ -64,11 +77,7 @@ const Comment = ({
             {memberId === comments.memberId || memberId === 1 ? (
               <DP.PostManageButtonContainer>
                 {isEdit && commentIdx === comments.commentId ? (
-                  <DP.PostManageButton
-                    onClick={() =>
-                      modifiedComment(comments.commentId, editcommentContent)
-                    }
-                  >
+                  <DP.PostManageButton onClick={handleEditComplete}>
                     완료
                   </DP.PostManageButton>
                 ) : (

--- a/Client/src/data/userData.ts
+++ b/Client/src/data/userData.ts
@@ -1,0 +1,2 @@
+export const profileImg =
+  "https://lh3.googleusercontent.com/pw/AMWts8CEDi2m6IeYf8S0FGfXum-T0_vsJIa1geotAKan_2NzfhOcgYgrtrfd8mjMtVfZ0BCUPDXoUPos9yV5VWgy8eSvzMBs-4jA3Xq0ocmQhpTqPSWQ8lXrK8LsMWISS3vZbZR6Y74ztKYybTTmXQ966bEx=s407-no?authuser=0";


### PR DESCRIPTION
## 작업 내용

- 댓글 수정 버튼을 누르고 수정 없이 다시 완료 버튼을 눌렀을때 빈값으로 서버에 전송되는 오류 해결

## 추가 변경 사항

- AddComment 컴포넌트의 사용자 프로필 이미지 주소 업데이트