### PR TITLE
fix: 포스트 에디터 페이지 버그 수정

### DIFF
--- a/Client/src/api/postEditor/handlePostSubmit.ts
+++ b/Client/src/api/postEditor/handlePostSubmit.ts
@@ -7,11 +7,12 @@ export const handlePostSubmit = async (
   content: string[],
   postId: string | undefined
 ) => {
-  let result = "";
+  let result = null;
   if (title === "") {
     alert("제목을 입력해주세요");
-  } else if (imgList.length === 0) alert("이미지를 등록해주세요.");
-  else {
+  } else if (imgList.length === 0) {
+    alert("이미지를 등록해주세요.");
+  } else {
     const formData = new FormData();
     formData.append("postTitle", title);
     tags.forEach((tag) => {
@@ -23,14 +24,16 @@ export const handlePostSubmit = async (
     content.forEach((text) => {
       formData.append("postContents", text);
     });
-    await apiClient
-      .post(`/posts/register/${postId}`, formData, {
+    try {
+      const res = await apiClient.post(`/posts/register/${postId}`, formData, {
         headers: {
           "Content-Type": "multipart/form-data",
         },
-      })
-      .then((res) => (result = res.data.data.postId))
-      .catch((err) => console.error(err));
+      });
+      result = res.data.data.postId;
+    } catch (err) {
+      console.error(err);
+    }
   }
   return result;
 };

--- a/Client/src/hooks/useUnsavedChangesWarning.ts
+++ b/Client/src/hooks/useUnsavedChangesWarning.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+const useUnsavedChangesWarning = (shouldWarn: boolean) => {
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (shouldWarn) {
+        event.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [shouldWarn]);
+  return null;
+};
+
+export default useUnsavedChangesWarning;

--- a/Client/src/pages/PostEditor/index.tsx
+++ b/Client/src/pages/PostEditor/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import { handlePostSubmit } from "~/api/postEditor/handlePostSubmit";
 import Button from "~/components/@common/Button";
 import {
@@ -18,22 +18,30 @@ import { MdOutlineKeyboardBackspace } from "react-icons/md";
 import { CgClose } from "react-icons/cg";
 import { getPost } from "~/api/post/getPost";
 import * as S from "./styled";
+import useUnsavedChangedWarning from "~/hooks/useUnsavedChangesWarning";
 interface PostEditorProps {
   mode: "edit" | "new";
 }
 
 function PostEditor({ mode }: PostEditorProps) {
   const [title, setTitle] = useState("");
+  const [imgFiles, setImgFiles] = useState<File[]>([]);
+  const [showImageUploader, setShowImageUploader] = useState(false);
+  const [isWriteGuideModal, setIsWriteGuideModal] = useState(false);
   const [tagList, setTagList] = useRecoilState(editorTagListAtom);
   const [postPreviewList, setPostPreviewList] = useRecoilState(
     editorPreviewListAtom
   );
-  const postContent = useRecoilValue(editorPostContentAtom);
-  const [imgFiles, setImgFiles] = useState<File[]>([]);
-  const [showImageUploader, setShowImageUploader] = useState(false);
-  const [isWriteGuideModal, setIsWriteGuideModal] = useState(true);
+  const [postContent, setPostContent] = useRecoilState(editorPostContentAtom);
   const { targetId } = useParams();
   const navigate = useNavigate();
+
+  const shouldWarn = !(
+    title === "" &&
+    imgFiles.length === 0 &&
+    tagList.length === 0
+  );
+  useUnsavedChangedWarning(shouldWarn);
 
   useEffect(() => {
     if (mode === "edit") {
@@ -49,7 +57,14 @@ function PostEditor({ mode }: PostEditorProps) {
       };
       getData();
     }
+    return () => {
+      setTagList([]);
+      setPostPreviewList([]);
+      setPostContent([]);
+      setPostContent([]);
+    };
   }, []);
+
   const handleTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
     if (title.length > 30) alert("30자 이내로 작성해주세요.");
@@ -98,9 +113,9 @@ function PostEditor({ mode }: PostEditorProps) {
           </span>
           <Button
             type="violet"
-            width="80px"
-            height="20px"
-            text="가이드 보기"
+            width="120px"
+            height="30px"
+            text="작성 가이드 보기"
             onClick={() => setIsWriteGuideModal(true)}
           />
         </div>

--- a/Client/src/pages/PostEditor/index.tsx
+++ b/Client/src/pages/PostEditor/index.tsx
@@ -90,14 +90,16 @@ function PostEditor({ mode }: PostEditorProps) {
 
   const actionPostSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    const post = await handlePostSubmit(
+    const postId = await handlePostSubmit(
       title,
       tagList,
       imgFiles,
       postContent,
       targetId
     );
-    navigate(`/posts/detail/${post}`);
+    if (postId !== null) {
+      navigate(`/posts/detail/${postId}`);
+    }
   };
 
   return (


### PR DESCRIPTION
## 작업 내용

- 포스트 에디터 페이지에서 이전에 작성중이던 포스트 데이터가 계속 남아있는 현상 해결
- 제목 미입력, 이미지 미등록 시에도 alert창이 뜬 다음 바로 포스트 상세 페이지로 넘어가는 오류 해결

## 추가 변경 사항

- 포스트 에디터 페이지에서 포스트를 등록하지 않고 다른 화면으로 이동할 때 (앞,뒤로가기 제외)  "변경사항이 저장되지 않을 수 있습니다." 창 띄우는 커스텀 훅 추가
- 포스트 에디터 페이지에서는 입력된 제목, 이미지 파일, 태그가 존재할 때만 창을 띄움